### PR TITLE
Fix PyQt6 startup failures: version drift + UF_HIDDEN cocoa plugin flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Running the Application
+
+CARA is a PyQt6-based desktop chess analysis application. Start it with:
+
+```bash
+python cara.py
+```
+
+On macOS, you may need `python3` instead. Requires Python 3.8+ and a UCI-compatible chess engine (Stockfish, Berserk, etc.) configured via the Engines menu.
+
+**PyQt6 / PyQt6-Qt6 version pinning.** `requirements.txt` pins both `PyQt6` and `PyQt6-Qt6` to the same exact version. They must match — a mismatch produces a misleading error (`Could not find the Qt platform plugin "cocoa"`) that looks like a missing file, broken signature, or corrupt install, none of which is the actual cause. A plain `pip install -r requirements.txt` on a clean venv should no longer produce drift.
+
+If you hit this error despite installing from `requirements.txt` (e.g. after manually upgrading one package), diagnose with:
+
+```bash
+pip show PyQt6 PyQt6-Qt6 | grep -E "Name|Version"
+```
+
+If the versions don't match, reinstall whichever one is ahead to match the other:
+
+```bash
+pip install --force-reinstall --no-deps PyQt6-Qt6==<matching version>
+```
+
+PyPI doesn't always have every point-release pair available for both packages — run `pip install PyQt6-Qt6==` (no version, to list what's available) if the exact match isn't found.
+
+## Running Tests
+
+Tests use Python's standard `unittest` framework, living in `tests/` as `test_*.py`.
+
+```bash
+# All tests
+python -m unittest discover -s tests -p "test_*.py" -v
+
+# A specific subdirectory
+python -m unittest discover -s tests/services -p "test_*.py" -v
+
+# A single file, class, or method — same dotted-path pattern
+python -m unittest tests.services.test_pgn_service -v
+python -m unittest tests.services.test_pgn_service.TestPgnServiceNormalizeMovesFixedWidth -v
+```
+
+**Note**: Tests in `tests/opening_integrity/` require local chess engine installations — local only, not run in CI.
+
+## Building
+
+PyInstaller specs exist for macOS, Windows, and Linux (`CARA_macos.spec`, etc. — each requires its target OS to build).
+
+```bash
+pip install pyinstaller==6.17.0
+pyinstaller CARA_macos.spec  # or _windows / _linux
+```
+
+Output bundles land in `dist/`.
+
+## Dependencies
+
+See `requirements.txt` for the full, versioned list. One choice worth knowing the reasoning behind: **asteval**, not raw `eval()`, is used for evaluating user-defined expressions — a deliberate safety choice, not an oversight.
+
+```bash
+pip install -r requirements.txt
+```
+
+## Architecture
+
+CARA follows **PyQt's Model/View pattern with Controllers**, with signal/slot communication throughout.
+
+1. **Models** (`app/models/`) — Qt data models holding application state. Table models (DatabaseModel, MovesListModel, MetadataModel) inherit `QAbstractTableModel`; state models (BoardModel, GameModel, EvaluationModel) inherit `QObject` and emit custom signals. UI-independent and testable in isolation.
+
+2. **Views** (`app/views/`) — UI components. Display data by observing model signals; never modify model data directly — go through a controller instead. All styling comes from `app/config/config.json` (see Configuration below).
+
+3. **Controllers** (`app/controllers/`) — Handle user interactions from views, update models, call services. No UI logic. Entry point: `AppController` wires all feature controllers together.
+
+4. **Services** (`app/services/`, ~129 files) — Computation, file I/O, engine management, analysis algorithms. UI-independent and testable in isolation.
+
+5. **Configuration** (`app/config/`) — see Configuration System below.
+
+6. **Utils** (`app/utils/`) — Font, path, styling, and tooltip helpers.
+
+### Signal/Slot Communication
+
+- Model → View: models emit on data change, views observe and update automatically.
+- View → Controller: views call controller methods on user interaction.
+- Controller → Model / Controller → Service: controllers update models and invoke service logic.
+- Thread → UI: worker threads emit signals for thread-safe UI updates.
+
+## Configuration System
+
+Three files loaded at startup: `app/config/config.json` (UI styling/dimensions/colors/fonts), `user_settings.json` (user preferences), `engine_parameters.json` (UCI engine parameters).
+
+**Config is split by kind, not just by file.** `config.json` holds *behavioral* config; the `style_*.config.json` theme files hold *style/layout* config. ConfigLoader merges both into memory at startup — treat them as one logical config in code, but a new key's *home file* depends on whether it's behavior or presentation, not convenience.
+
+**Convention for new config keys (confirmed by maintainer):** add every new key to ConfigLoader so a missing one fails loudly at startup. Whether the corresponding `.get()` call in code also carries an inline default doesn't matter either way — the loader is the actual gate, `.get()` defaults are just belt-and-suspenders. (The strict-validation-everywhere language elsewhere in this doc is aspirational, not fully true yet — it's known tech debt from a mid-project design shift, with a config-loader refactor planned but not yet done. Don't be surprised by `.get(..., default)` patterns in the existing code; follow the "always register in ConfigLoader" rule for anything new regardless.)
+
+Style config files (`style_default.config.json`, `style_light.config.json`, `style_scholar.config.json`) define reusable constants with a `$_` prefix, referenced elsewhere via `{"$ref": "$_CONSTANT_NAME"}`. `config.json`'s `default_style_config` key selects the active style file.
+
+Key sections: `ui.window`, `ui.panels`, `ui.dialogs.*`, `ui.styles`, `ui.colors`, `ui.fonts`, `version`.
+
+### Configuration Access
+
+```python
+bg_color = config.get("ui", {}).get("dialogs", {}).get("my_dialog", {}).get("background_color", [40, 40, 45])
+```
+
+**Note:** the docs describe ConfigLoader as strictly validating at startup, but the pattern above uses `.get()` with an inline default — that's not a contradiction to resolve, it's the current transitional state (see Configuration System above). For new config-reading code: register the key in ConfigLoader regardless of whether you also add a `.get()` default.
+
+### Dialog Implementation
+
+Dialogs follow a standard constructor pattern: load config → build UI → apply styling via `StyleManager` (`app/views/style/style_manager.py`). Use `scale_font_size()` and `resolve_font_family()` from `app.utils.font_utils` for font values from config. See `app/views/dialogs/bulk_operations_dialog.py` as the living template rather than a static skeleton here.
+
+## Threading
+
+- **QThread** for I/O-bound engine operations (EvaluationEngineThread, GameAnalysisEngineThread, ManualAnalysisEngineThread) — Qt handles thread safety via signals/slots.
+- **ProcessPoolExecutor** for CPU-bound work (player statistics, PGN parsing, multi-file opening), using `max(1, os.cpu_count() - 2)` workers to keep the UI responsive.
+
+## Key Subsystems
+
+### Game Analysis Pipeline
+GameAnalysisController → GameAnalysisEngineService (runs engine per move, MultiPV) → MoveClassificationService (Good/Inaccuracy/Mistake/Blunder/Brilliancy by Centipawn Loss) → MovesListModel → GameSummaryService (aggregated statistics, highlights, top moves).
+
+### Game Highlights
+Rule-based detection of 44+ tactical/positional patterns, one rule per file in `app/services/game_highlights/rules/`, each implementing a common interface. Tests: one file per rule in `tests/highlight_rules/`. Extend by adding a new rule file.
+
+### Positional Heatmap
+Same extensible rule-based architecture as Game Highlights, in `app/services/positional_heatmap/rules/` — weak squares, passed pawns, outposts, piece activity, king safety.
+
+### Player Statistics
+Per-player aggregation: accuracy/progression charts, opening/endgame summaries, significant moves, activity heatmap, and **error pattern hints with pattern detection** — worth a direct look before building anything that tracks recurring mistakes, since it may already do part of that job.
+
+## Naming Conventions
+
+- Controllers: `*_controller.py` / `*Controller`
+- Models: `*_model.py` / `*Model`
+- Services: `*_service.py` / `*Service`
+- Views: `*_view.py` or `*_panel.py` / `*View` or `*Panel`
+- Dialogs: `*_dialog.py` / `*Dialog`
+- Tests: `test_*.py` / `Test*`
+- Signals: `<noun>_changed` (e.g. `position_changed`, `evaluation_updated`)
+- Config keys: dotted notation (`"ui.dialogs.my_dialog.width"`)
+
+## Documentation
+
+Architecture and feature docs live in `doc/` — `architecture_outline.md` for high-level design/threading/error handling, `dialog_style_guide.md` for the dialog pattern, plus feature-specific docs (game analysis, highlights, heatmap, player stats, annotations). Check there before re-deriving something already documented.
+
+## Git Workflow
+
+- **Never commit directly to `master`.** Always work on a feature branch.
+- Prefer small, focused commits (one logical change each) over large batched ones — easier to review, easier to revert if something's wrong.
+
+## CI/CD
+
+`.github/workflows/tests.yml` runs on Python 3.12 with `QT_QPA_PLATFORM=offscreen` for headless Qt testing, on push to `master`/`development` and on PRs. Manual-trigger build workflows (`build-appbundles.yml`, `build-linux-appbundles.yml`) produce macOS/Windows/Linux bundles as artifacts.
+
+## Version and Release
+
+Version lives in `app/config/config.json` under `"version"` — build scripts read it for bundle naming. Release notes in `RELEASE_NOTES.md`; pre-built bundles on the GitHub Releases page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,22 @@ pip install --force-reinstall --no-deps PyQt6-Qt6==<matching version>
 
 PyPI doesn't always have every point-release pair available for both packages — run `pip install PyQt6-Qt6==` (no version, to list what's available) if the exact match isn't found.
 
+**macOS UF_HIDDEN platform-plugin flag.** macOS sometimes sets the `UF_HIDDEN` file flag on `libqcocoa.dylib` and sibling Qt platform plugins during pip extraction. The flag is invisible to permissions, dlopen, and codesigning checks but prevents Qt plugin discovery, producing the same misleading "Could not find the Qt platform plugin 'cocoa'" error. CARA clears this flag automatically at every startup (`app/utils/macos_startup.py` → `clear_platform_plugin_hidden_flags()` called in `cara.py` before `QApplication` is constructed). If you somehow still hit the error after startup has run (e.g., running Python directly without going through `cara.py`), clear manually:
+
+```bash
+python3 -c "
+import os, glob
+plugins = glob.glob(os.path.expanduser('~/.venv/lib/python*/site-packages/PyQt6/Qt6/plugins/platforms/*.dylib'))
+for p in plugins:
+    st = os.lstat(p)
+    if hasattr(st, 'st_flags') and st.st_flags & 0x8000:
+        os.chflags(p, st.st_flags & ~0x8000)
+        print('cleared', p)
+"
+```
+
+(Adjust the venv path to match yours.)
+
 ## Running Tests
 
 Tests use Python's standard `unittest` framework, living in `tests/` as `test_*.py`.

--- a/app/utils/macos_startup.py
+++ b/app/utils/macos_startup.py
@@ -1,0 +1,66 @@
+"""macOS startup helpers that must run before QApplication is constructed."""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+
+# UF_HIDDEN is 0x8000 in <sys/stat.h> on macOS.
+_UF_HIDDEN = 0x8000
+
+
+def clear_platform_plugin_hidden_flags() -> None:
+    """Clear the UF_HIDDEN file flag from Qt's platform-plugins directory.
+
+    macOS sometimes sets UF_HIDDEN on libqcocoa.dylib (and sibling plugins)
+    during pip's download/extraction.  The flag is invisible to every
+    file-integrity check — permissions, dlopen, codesigning, and architecture
+    all look fine — but prevents Qt's own plugin-discovery from succeeding,
+    causing QGuiApplicationPrivate::createPlatformIntegration() to qFatal-abort
+    with "Could not find the Qt platform plugin 'cocoa'".  The flag can
+    reassert itself between process launches, so this runs unconditionally on
+    every macOS startup rather than as a one-time fix.
+
+    Safe to call on any platform: returns immediately on non-macOS.  All errors
+    are suppressed; this must never prevent startup.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        import PyQt6  # noqa: PLC0415  (late import by design)
+        plugins_dir = os.path.join(
+            os.path.dirname(PyQt6.__file__), "Qt6", "plugins", "platforms"
+        )
+        _clear_hidden_recursive(plugins_dir)
+    except Exception as exc:  # pragma: no cover
+        # Swallow everything — a broken path, missing permission, or non-standard
+        # PyQt6 layout must never abort startup.
+        warnings.warn(
+            f"macOS UF_HIDDEN cleanup skipped ({type(exc).__name__}: {exc})",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def _clear_hidden_recursive(path: str) -> None:
+    """Clear UF_HIDDEN from *path* and each file directly inside it if it's a directory."""
+    _clear_hidden_flag(path)
+    try:
+        if os.path.isdir(path):
+            for name in os.listdir(path):
+                _clear_hidden_flag(os.path.join(path, name))
+    except OSError:
+        pass
+
+
+def _clear_hidden_flag(path: str) -> None:
+    """Clear UF_HIDDEN from a single file or directory; silently ignores errors."""
+    try:
+        st = os.lstat(path)
+        current = getattr(st, "st_flags", 0)
+        if current & _UF_HIDDEN:
+            os.chflags(path, current & ~_UF_HIDDEN)  # type: ignore[attr-defined]
+    except (OSError, AttributeError):
+        pass

--- a/cara.py
+++ b/cara.py
@@ -67,6 +67,7 @@ from app.main_window import MainWindow
 from app.services.error_handler import ErrorHandler
 from app.utils.path_resolver import get_app_resource_path
 from app.services.theme_service import load_saved_theme_style_ref
+from app.utils.macos_startup import clear_platform_plugin_hidden_flags
 
 def _is_kde_plasma_session() -> bool:
     """Best-effort detection of KDE Plasma desktop sessions (Linux only)."""
@@ -123,7 +124,11 @@ def main() -> None:
     """Run CARA: Chess Analysis Review Application."""
 
     _disable_plasma_platform_theme_plugin()
-    
+
+    # Clear UF_HIDDEN from Qt's platform plugins on macOS before QApplication.
+    # The flag can be set by pip during extraction and prevents plugin discovery.
+    clear_platform_plugin_hidden_flags()
+
     # Suppress harmless Qt font warnings before creating QApplication
     qInstallMessageHandler(_qt_message_handler)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-PyQt6>=6.6.0
+PyQt6==6.11.0
+PyQt6-Qt6==6.11.0
+PyQt6-sip>=13.8,<14
 python-chess>=1.999
 requests>=2.31.0
 asteval>=0.9.31
 charset-normalizer>=3.0.0
-

--- a/tests/test_macos_startup.py
+++ b/tests/test_macos_startup.py
@@ -1,0 +1,166 @@
+"""Tests for app.utils.macos_startup — the UF_HIDDEN platform-plugin guard.
+
+These tests cover the safety contracts: the helper must never raise,
+never block startup, and correctly clear the UF_HIDDEN bit when present.
+Platform-specific paths are mocked so the tests run on all OSes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.utils.macos_startup import (
+    _UF_HIDDEN,
+    _clear_hidden_flag,
+    _clear_hidden_recursive,
+    clear_platform_plugin_hidden_flags,
+)
+
+
+class TestClearHiddenFlag(unittest.TestCase):
+    """Unit tests for the low-level _clear_hidden_flag helper."""
+
+    def test_clears_uf_hidden_when_set(self):
+        calls = []
+
+        def fake_lstat(path):
+            st = MagicMock()
+            st.st_flags = _UF_HIDDEN | 0x0040  # hidden + tracked
+            return st
+
+        def fake_chflags(path, flags):
+            calls.append((path, flags))
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat), \
+             patch("app.utils.macos_startup.os.chflags", fake_chflags):
+            _clear_hidden_flag("/fake/libqcocoa.dylib")
+
+        self.assertEqual(len(calls), 1)
+        _, new_flags = calls[0]
+        self.assertFalse(new_flags & _UF_HIDDEN, "UF_HIDDEN should have been cleared")
+        self.assertTrue(new_flags & 0x0040, "Other flags should be preserved")
+
+    def test_noop_when_flag_not_set(self):
+        calls = []
+
+        def fake_lstat(path):
+            st = MagicMock()
+            st.st_flags = 0x0040  # tracked, no hidden
+            return st
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat), \
+             patch("app.utils.macos_startup.os.chflags", lambda p, f: calls.append((p, f))):
+            _clear_hidden_flag("/fake/libqcocoa.dylib")
+
+        self.assertEqual(calls, [], "chflags should not be called if flag is not set")
+
+    def test_silently_ignores_oserror_on_lstat(self):
+        with patch("app.utils.macos_startup.os.lstat", side_effect=OSError("no permission")):
+            _clear_hidden_flag("/nonexistent/path")  # must not raise
+
+    def test_silently_ignores_oserror_on_chflags(self):
+        def fake_lstat(path):
+            st = MagicMock()
+            st.st_flags = _UF_HIDDEN
+            return st
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat), \
+             patch("app.utils.macos_startup.os.chflags", side_effect=OSError("read-only")):
+            _clear_hidden_flag("/fake/path")  # must not raise
+
+    def test_handles_stat_without_st_flags(self):
+        """Non-macOS stat objects lack st_flags — should be a no-op."""
+        def fake_lstat(path):
+            st = MagicMock(spec=[])  # no attributes at all
+            return st
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat):
+            _clear_hidden_flag("/fake/path")  # must not raise
+
+
+class TestClearHiddenRecursive(unittest.TestCase):
+    def test_clears_directory_and_children(self):
+        cleared = []
+
+        def fake_lstat(path):
+            st = MagicMock()
+            st.st_flags = _UF_HIDDEN
+            return st
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat), \
+             patch("app.utils.macos_startup.os.chflags", lambda p, f: cleared.append(p)), \
+             patch("app.utils.macos_startup.os.path.isdir", return_value=True), \
+             patch("app.utils.macos_startup.os.listdir", return_value=["libqcocoa.dylib", "libqminimal.dylib"]):
+            _clear_hidden_recursive("/fake/platforms")
+
+        # Should clear the dir itself + both children
+        self.assertEqual(len(cleared), 3)
+
+    def test_silently_ignores_listdir_error(self):
+        def fake_lstat(path):
+            st = MagicMock()
+            st.st_flags = 0  # no hidden
+            return st
+
+        with patch("app.utils.macos_startup.os.lstat", fake_lstat), \
+             patch("app.utils.macos_startup.os.path.isdir", return_value=True), \
+             patch("app.utils.macos_startup.os.listdir", side_effect=OSError("permission denied")):
+            _clear_hidden_recursive("/fake/platforms")  # must not raise
+
+
+class TestClearPlatformPluginHiddenFlags(unittest.TestCase):
+    """Tests for the public entry-point."""
+
+    def test_noop_on_non_macos(self):
+        """On non-macOS platforms the function must return immediately."""
+        with patch("app.utils.macos_startup.sys.platform", "linux"):
+            clear_platform_plugin_hidden_flags()  # must not raise or do anything
+
+    def test_noop_on_windows(self):
+        with patch("app.utils.macos_startup.sys.platform", "win32"):
+            clear_platform_plugin_hidden_flags()
+
+    def test_handles_missing_pyqt6(self):
+        """If PyQt6 is not importable the function must not raise."""
+        with patch("app.utils.macos_startup.sys.platform", "darwin"), \
+             patch("builtins.__import__", side_effect=ImportError("no PyQt6")):
+            clear_platform_plugin_hidden_flags()  # must not raise
+
+    def test_handles_nonexistent_plugins_dir(self):
+        """If the plugins directory doesn't exist, must not raise."""
+        fake_pyqt6 = MagicMock()
+        fake_pyqt6.__file__ = "/nonexistent/PyQt6/__init__.py"
+
+        with patch("app.utils.macos_startup.sys.platform", "darwin"), \
+             patch.dict("sys.modules", {"PyQt6": fake_pyqt6}):
+            clear_platform_plugin_hidden_flags()  # must not raise
+
+    def test_macos_clears_flags_in_plugins_dir(self):
+        """On darwin: locates the plugins dir and calls _clear_hidden_recursive."""
+        fake_pyqt6 = MagicMock()
+        fake_pyqt6.__file__ = "/fake/site-packages/PyQt6/__init__.py"
+        expected_dir = "/fake/site-packages/PyQt6/Qt6/plugins/platforms"
+
+        cleared = []
+        with patch("app.utils.macos_startup.sys.platform", "darwin"), \
+             patch.dict("sys.modules", {"PyQt6": fake_pyqt6}), \
+             patch("app.utils.macos_startup._clear_hidden_recursive",
+                   side_effect=lambda p: cleared.append(p)) as mock_clear:
+            clear_platform_plugin_hidden_flags()
+
+        self.assertEqual(cleared, [expected_dir])
+
+    def test_exception_inside_does_not_propagate(self):
+        """Any unexpected exception must be swallowed (startup must never be blocked)."""
+        with patch("app.utils.macos_startup.sys.platform", "darwin"), \
+             patch("app.utils.macos_startup._clear_hidden_recursive",
+                   side_effect=RuntimeError("unexpected")):
+            # Even if _clear_hidden_recursive blows up, no exception escapes
+            clear_platform_plugin_hidden_flags()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two independent bugs, both producing the identical startup failure on macOS
(`Could not find the Qt platform plugin "cocoa"`), diagnosed and fixed
separately since they have unrelated root causes.

## Bug 1: PyQt6 / PyQt6-Qt6 version drift

`requirements.txt` pinned only `PyQt6>=6.6.0`, leaving `PyQt6-Qt6` and
`PyQt6-sip` unpinned as transitive dependencies. `PyQt6-Qt6` gets more
frequent point releases on PyPI than `PyQt6` itself, so a plain
`pip install -r requirements.txt` on a clean environment can resolve them to
different versions (confirmed: `PyQt6==6.11.0` paired with
`PyQt6-Qt6==6.11.2`). The two packages must match — a mismatch fails at
startup with a misleading error that looks like a broken install rather
than a version issue.

**Fix:** pin `PyQt6`, `PyQt6-Qt6`, and `PyQt6-sip` to matching, explicit
versions in `requirements.txt`.

## Bug 2: `UF_HIDDEN` flag on the cocoa plugin (macOS, Apple Silicon)

Independent of Bug 1 — occurs even with correctly matched, correctly
installed PyQt6 packages. Root cause found via macOS's own crash report for
the `SIGABRT`: the abort happens inside Qt's own
`QGuiApplicationPrivate::createPlatformIntegration()`, i.e. Qt itself fails
to initialize the plugin and deliberately aborts — not a packaging,
signing, or architecture problem (all independently verified clean:
`dlopen` succeeds, correct arm64 architecture, valid ad-hoc signature,
correct linked frameworks).

Actual cause: macOS sometimes sets the `UF_HIDDEN` file flag on
`libqcocoa.dylib` (and its sibling platform plugins) during pip's
download/extraction. This flag is invisible to every standard integrity
check but interferes with Qt's own plugin discovery. It can also reassert
itself between process launches even after being cleared once, which is
why this was intermittent and hard to pin down.

**Fix:** clear the flag automatically at startup (`os.chflags`, macOS-only,
wrapped so a failure here never blocks app launch) before `QApplication` is
constructed in `cara.py` — self-healing on every launch, rather than a
manual step a developer has to remember and repeat.

## Testing

- Confirmed on a clean venv, installing only from the updated
  `requirements.txt`, that `PyQt6` and `PyQt6-Qt6` resolve to matching
  versions.
- Confirmed `cara.py` starts successfully with the `UF_HIDDEN` flag
  deliberately set beforehand (forcing the failure condition), with no
  manual `chflags` step.
- Confirmed `cara.py` still starts cleanly with the flag already clear
  (guard is a no-op in that case).

## Files changed

- `requirements.txt` — pinned `PyQt6`, `PyQt6-Qt6`, `PyQt6-sip`
- `cara.py` — startup guard clearing `UF_HIDDEN` on the platform plugins
  directory (macOS only)
- `CLAUDE.md` — documented both issues under "Running the Application,"
  including the automatic fix and manual fallback diagnostics